### PR TITLE
gqlEndpoints functionality tested and working

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,8 @@ export const validSettings = [
   'useMetrics',
   'cacheMethod',
   'cacheExpirationLimit',
-  'doNotCache',
-  'doNotCachev2',
+  'doNotCacheGlobal',
+  'doNotCacheCustom',
 ];
 
 export const defaultSettings = {
@@ -25,10 +25,8 @@ export const defaultSettings = {
   useMetrics: true,
   cacheMethod: 'cache-first',
   cacheExpirationLimit: null,
-  doNotCache: [],
-  doNotCachev2: { 
-    global: [null],
-  },
+  doNotCacheGlobal: [],
+  doNotCacheCustom: {},
 };
 
 /* Registers service worker pulled in during build steps of webpack/parcel/etc.


### PR DESCRIPTION
May need to include in config object comments/readMe that inputs to the gqlEndpoints array must conform to the URI general  syntax as defined in RFC 3986:
-via our current implementation of gqlEndpoints functionality if a developer adds 'api/graphql' to the respective array in settings, the caching logic will never execute because the actual URL behind the scenes is 'http://localhost:8080/api/graphql'

